### PR TITLE
Use ** to pass a hash as kwargs for Ruby 3.1 compatibility

### DIFF
--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -382,7 +382,7 @@ module StateMachine
           end
           
           default_options = default_error_message_options(object, attribute, message)
-          object.errors.add(attribute, message, options.merge(default_options))
+          object.errors.add(attribute, message, **options.merge(default_options))
         end
       end
       


### PR DESCRIPTION
Fix incompatibility with Ruby 3.1 due to the change in how keyword arguments are passed.

```rb
> Client.new.errors.add(:name, "test", { message: "blah" })
ArgumentError: wrong number of arguments (given 3, expected 1..2)
from gems/activemodel-6.1.7.1/lib/active_model/errors.rb:404:in `add'

> Client.new.errors.add(:name, "test", **{ message: "blah" })
=> #<ActiveModel::Error attribute=name, type=test, options={:message=>"blah"}>